### PR TITLE
fix: use default free memory offset

### DIFF
--- a/source/deterministic-deployment-proxy.yul
+++ b/source/deterministic-deployment-proxy.yul
@@ -8,8 +8,8 @@ object "Proxy" {
 	object "runtime" {
 		// deployed code
 		code {
-			calldatacopy(0, 0, calldatasize())
-			let result := create2(callvalue(), 0, calldatasize(), 0)
+			calldatacopy(0x80, 0, calldatasize())
+			let result := create2(callvalue(), 0x80, calldatasize(), 0)
 			if iszero(result) { revert(0, 0) }
 			mstore(0, result)
 			return(12, 20)


### PR DESCRIPTION
Hey @MicahZoltu thanks for this. I think I discovered a bug in the deploy logic. The calldata is being copied to memory offset at 0. This should fail if the calldata is more than 64 bytes. This PR switches the copy location to the default free memory offset.