### PR TITLE
feat: track nonce for each bytecode as salt

### DIFF
--- a/source/deterministic-deployment-proxy.yul
+++ b/source/deterministic-deployment-proxy.yul
@@ -9,7 +9,10 @@ object "Proxy" {
 		// deployed code
 		code {
 			calldatacopy(0, 0, calldatasize())
-			let result := create2(callvalue(), 0, calldatasize(), 0)
+			let hash := keccak256(0, calldatasize())
+			let nonce := sload(hash)
+			sstore(hash, add(nonce, 1))
+			let result := create2(callvalue(), 0, calldatasize(), nonce)
 			if iszero(result) { revert(0, 0) }
 			mstore(0, result)
 			return(12, 20)


### PR DESCRIPTION
This is QOL of thing to allow the same bytecode to be deployed multiple times. Mostly useful in test environments. I made this separate from #10 in case the one time deploy logic is intentional.